### PR TITLE
[Setting/#14] : DynamoDb 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // aws parameter store
     implementation 'org.springframework.cloud:spring-cloud-starter-aws-parameter-store-config:2.2.6.RELEASE'
 
+    //dynamoDB
+    implementation 'io.github.boostchicken:spring-data-dynamodb:5.2.5'
+
     testImplementation ('org.springframework.boot:spring-boot-starter-test')
     testImplementation 'jakarta.persistence:jakarta.persistence-api'
     testImplementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/com/sesacthon/ForecoApplication.java
+++ b/src/main/java/com/sesacthon/ForecoApplication.java
@@ -2,10 +2,10 @@ package com.sesacthon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@EnableJpaAuditing
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = "com.sesacthon.foreco")
 public class ForecoApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/sesacthon/global/response/DefaultResponse.java
+++ b/src/main/java/com/sesacthon/global/response/DefaultResponse.java
@@ -1,8 +1,11 @@
 package com.sesacthon.global.response;
 
+import lombok.Getter;
+
 /**
  * 공통된 응답 형식을 제공하기 위한 응답 Dto.
  */
+@Getter
 public abstract class DefaultResponse {
 
   /**

--- a/src/main/java/com/sesacthon/infra/dynamodb/Image.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/Image.java
@@ -1,0 +1,27 @@
+package com.sesacthon.infra.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@DynamoDBTable(tableName="TrashImg")
+@Getter
+@NoArgsConstructor
+public class Image {
+
+  @DynamoDBHashKey(attributeName = "trashCategory")
+  private String trashCategory;
+
+  @DynamoDBAttribute(attributeName = "imgUrl")
+  private String imgUrl;
+
+  @Builder
+  public Image(String trashCategory, String imageUrl) {
+    this.trashCategory = trashCategory;
+    this.imgUrl = imageUrl;
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/dynamodb/config/DynamoDbConfig.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/config/DynamoDbConfig.java
@@ -1,0 +1,51 @@
+package com.sesacthon.infra.dynamodb.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.sesacthon.infra.dynamodb.repository.SpringDataDynamoImageRepository;
+import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+@EnableDynamoDBRepositories(basePackageClasses = SpringDataDynamoImageRepository.class)
+public class DynamoDbConfig {
+
+  @Value("${cloud.aws.credentials.keys[1].access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.keys[1].secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  public AWSCredentialsProvider amazonAWSCredentialsProvider() {
+    return new AWSStaticCredentialsProvider(amazonAWSCredentials());
+  }
+
+  @Bean
+  public AWSCredentials amazonAWSCredentials() {
+    return new BasicAWSCredentials(accessKey, secretKey);
+  }
+
+  @Bean
+  @Primary
+  public DynamoDBMapperConfig dynamoDBMapperConfig() {
+    return DynamoDBMapperConfig.DEFAULT;
+  }
+
+  @Bean
+  public AmazonDynamoDB amazonDynamoDB() {
+    return AmazonDynamoDBClientBuilder.standard().withCredentials(amazonAWSCredentialsProvider())
+        .withRegion(region).build();
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/dynamodb/controller/ImgController.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/controller/ImgController.java
@@ -1,0 +1,22 @@
+package com.sesacthon.infra.dynamodb.controller;
+
+import com.sesacthon.infra.dynamodb.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ImgController {
+
+  private final StoreService storeService;
+
+  @PostMapping(value = "/api/v1/dynamodb/img" )
+  public String uploadEventImg (
+      @RequestParam("category") String trashCg, @RequestParam("imgUrl") String url) {
+      storeService.saveImg(trashCg, url);
+      return "ok";
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/dynamodb/repository/SpringDataDynamoImageRepository.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/repository/SpringDataDynamoImageRepository.java
@@ -1,0 +1,10 @@
+package com.sesacthon.infra.dynamodb.repository;
+
+import com.sesacthon.infra.dynamodb.Image;
+import org.socialsignin.spring.data.dynamodb.repository.EnableScan;
+import org.springframework.data.repository.CrudRepository;
+
+@EnableScan
+public interface SpringDataDynamoImageRepository extends CrudRepository<Image, String> {
+
+}

--- a/src/main/java/com/sesacthon/infra/dynamodb/repository/SpringDataImageRepository.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/repository/SpringDataImageRepository.java
@@ -1,0 +1,18 @@
+package com.sesacthon.infra.dynamodb.repository;
+
+import com.sesacthon.infra.dynamodb.Image;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class SpringDataImageRepository {
+
+  private final SpringDataDynamoImageRepository springDataDynamoImageRepository;
+
+  public void make(String category, String imgUrl) {
+    springDataDynamoImageRepository.save(new Image(category, imgUrl));
+  }
+
+
+}

--- a/src/main/java/com/sesacthon/infra/dynamodb/service/StoreService.java
+++ b/src/main/java/com/sesacthon/infra/dynamodb/service/StoreService.java
@@ -1,0 +1,17 @@
+package com.sesacthon.infra.dynamodb.service;
+
+import com.sesacthon.infra.dynamodb.repository.SpringDataImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+  private final SpringDataImageRepository imageRepository;
+
+  public void saveImg(String category, String imgUrl) {
+    imageRepository.make(category, imgUrl);
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/s3/config/S3Config.java
+++ b/src/main/java/com/sesacthon/infra/s3/config/S3Config.java
@@ -9,12 +9,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AmazonS3Config {
+public class S3Config {
 
-  @Value("${cloud.aws.credentials.access-key}")
+  @Value("${cloud.aws.credentials.keys[0].access-key}")
   private String accessKey;
 
-  @Value("${cloud.aws.credentials.secret-key}")
+  @Value("${cloud.aws.credentials.keys[0].secret-key}")
   private String secretKey;
 
   @Value("${cloud.aws.region.static}")
@@ -28,5 +28,4 @@ public class AmazonS3Config {
         .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
         .build();
   }
-
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,13 +26,16 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
-        database-platform: org.hibernate.dialect.MySQL8Dialect
+        database-platform: org.hibernate.dialect.MySQLDialect
 
 cloud:
   aws:
     credentials:
-      access-key: ${S3_ACCESS}
-      secret-key: ${S3_SECRET}
+      keys:
+        - access-key: ${S3_ACCESS}
+          secret-key: ${S3_SECRET}
+        - access-key: ${DYNAMO_ACCESS}
+          secret-key: ${DYNAMO_SECRET}
     s3:
       bucket: ${S3_BUCKET}
     stack:


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #14 

## 🔑 Key Changes

1. aws dynamodb 관련 의존성 추가
(`boostchicken/spring-data-dynamodb 참고`)
2. dynamoDB에 저장할 엔티티 생성(AI 모델에 학습할 사진 저장소)
3. Spring Data JPA를 같이 사용할 때, dynamoDB가 사용하는 repository는 JPA repository빈으로 인식 못하게 추가 설정 
(`ForecoApplication.class에 @EnableDynamoDBRepositories 추가`)
4. DynamoDB 관련 repository, service 생성

## 📢 To Reviewers
- Nothing