### PR TITLE
[Fix/#41]: codeDeploy가 환경변수 읽도록 한다.

### DIFF
--- a/scripts/run_new_was.sh
+++ b/scripts/run_new_was.sh
@@ -11,7 +11,7 @@ elif [ ${CURRENT_PORT} -eq 8082 ]; then
   TARGET_PORT=8081
 else
   echo "> No WAS is connected to nginx"
-fi
+fi가
 
 TARGET_PID=$(lsof -Fp -i TCP:${TARGET_PORT} | grep -Po 'p[0-9]+' | grep -Po '[0-9]+')
 
@@ -20,7 +20,6 @@ if [ ! -z ${TARGET_PID} ]; then
   sudo kill ${TARGET_PID}
 fi
 
-source ~/.bashrc
 nohup java -jar -Dserver.port=${TARGET_PORT} /home/ec2-user/foreco-aws-application/build/libs/* > /home/ec2-user/nohup.out 2>&1 &
 echo "> Now new WAS runs at ${TARGET_PORT}."
 exit 0

--- a/scripts/run_new_was.sh
+++ b/scripts/run_new_was.sh
@@ -20,6 +20,7 @@ if [ ! -z ${TARGET_PID} ]; then
   sudo kill ${TARGET_PID}
 fi
 
+source ~/.bashrc
 nohup java -jar -Dserver.port=${TARGET_PORT} /home/ec2-user/foreco-aws-application/build/libs/* > /home/ec2-user/nohup.out 2>&1 &
 echo "> Now new WAS runs at ${TARGET_PORT}."
 exit 0


### PR DESCRIPTION
bashrc에 환경변수를 invalid 타입으로 확인하여 제거 후, `/etc/profile.d/codedeploy.sh에 환경변수를 추가`했습니다.