### PR TITLE
[Feat/#72]: 카카오 로그인 기능 및 게스트 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "2022.0.1")
+    set('springCloudVersion', "2022.0.2")
 }
 
 dependencyManagement {
@@ -61,11 +61,29 @@ dependencies {
     //Swagger Docs
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    //properties 프로세서
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
     testImplementation ('org.springframework.boot:spring-boot-starter-test')
     testImplementation 'jakarta.persistence:jakarta.persistence-api'
     testImplementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    //UUID
+    implementation 'com.github.f4b6a3:uuid-creator:5.3.2'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+    //open-feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 /** clean 태스크 실행시 QClass 삭제 */

--- a/src/main/java/com/sesacthon/ForecoApplication.java
+++ b/src/main/java/com/sesacthon/ForecoApplication.java
@@ -2,14 +2,30 @@ package com.sesacthon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaRepositories(basePackages = "com.sesacthon.foreco")
 public class ForecoApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(ForecoApplication.class, args);
+  }
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(
+                "클라이언트 도메인 주소");
+      }
+    };
   }
 
 }

--- a/src/main/java/com/sesacthon/foreco/common/BaseTimeEntity.java
+++ b/src/main/java/com/sesacthon/foreco/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.sesacthon.foreco.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "CREATED_AT")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "MODIFIED_AT")
+  private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/controller/JwtController.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/controller/JwtController.java
@@ -1,0 +1,33 @@
+package com.sesacthon.foreco.jwt.controller;
+
+import static com.sesacthon.foreco.member.service.MemberSignUpService.setCookieAndHeader;
+
+import com.sesacthon.foreco.jwt.dto.ReIssueTokenDto;
+import com.sesacthon.foreco.jwt.service.JwtTokenReissueService;
+import com.sesacthon.global.response.MessageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name="토큰 관련 컨트롤러", description = "토큰을 재발급할 수 있다.")
+public class JwtController {
+  private final JwtTokenReissueService jwtTokenReissueService;
+
+  @GetMapping("/api/v1/jwt/refresh")
+  @Operation(summary = "Jwt 재발급", description = "Jwt를 재발급 할 수 있습니다.")
+  public ResponseEntity<MessageResponse> reIssueToken(@CookieValue(name = "refreshToken") String refreshToken) {
+    ReIssueTokenDto reIssueTokenDto = jwtTokenReissueService.reIssueToken(refreshToken);
+    HttpHeaders headers = setCookieAndHeader(reIssueTokenDto);
+    return new ResponseEntity<>(
+        MessageResponse.of(HttpStatus.CREATED, "Token 재발급 성공"), headers, HttpStatus.CREATED);
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/dto/ReIssueTokenDto.java
@@ -1,0 +1,16 @@
+package com.sesacthon.foreco.jwt.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReIssueTokenDto {
+
+  private final String refreshToken;
+
+  private final String accessToken;
+
+  public ReIssueTokenDto(String accessToken, String refreshToken) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/dto/SessionUser.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/dto/SessionUser.java
@@ -1,0 +1,21 @@
+package com.sesacthon.foreco.jwt.dto;
+
+import com.sesacthon.foreco.member.entity.Member;
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SessionUser implements Serializable {
+
+  private final UUID uuid;
+  private final String authority;
+
+  public SessionUser(Member member) {
+    this.uuid = member.getId();
+    this.authority = member.getRole().getAuthority();
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/exception/JwtException.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/exception/JwtException.java
@@ -1,0 +1,19 @@
+package com.sesacthon.foreco.jwt.exception;
+
+
+import com.sesacthon.global.exception.ErrorCode;
+
+public class JwtException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public JwtException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/filter/JwtAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/filter/JwtAuthenticationEntryPointHandler.java
@@ -1,0 +1,25 @@
+package com.sesacthon.foreco.jwt.filter;
+
+import static com.sesacthon.global.exception.ErrorCode.RESOURCE_UNAUTHORIZED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sesacthon.global.exception.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json;charset=UTF-8");
+    objectMapper.writeValue(response.getWriter(), ErrorResponse.of(RESOURCE_UNAUTHORIZED));
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,63 @@
+package com.sesacthon.foreco.jwt.filter;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.sesacthon.foreco.jwt.service.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  /**
+   * 1. request header 에서 Authorization 값을 가져온다.
+   *
+   * 1-1. Authorization 값이 없다면? 사용자가 처음 요청
+   * accessToken 발급 / 해당 유저를 저장한 후에 UUID를 발급하여 응답한다.
+   *
+   * 1-2. Authorization 값이 있다면? 유효성 검증
+   * 토큰이 올바른지와 만료됐는지 검증한다.
+   * 유효성 검증에서 실패하면 정의한 예외 처리를 해준다.
+   */
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    //사용자의 요청 헤더에서 Authorization 값을 가져온다.
+    String header = request.getHeader(AUTHORIZATION);
+
+    if(validateHeader(header)) {
+      // 헤더에서 JWT를 받아온다.
+      String accessToken = header.substring(7);
+
+      log.info("accessToken: {} 으로 Authentication 객체를 찾습니다.", accessToken);
+      Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+      //SecurityContext에 Authentication 객체를 저장한다.
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+      log.info("SecurityContextHolder 에 Authentication 객체를 저장했습니다. 인증 완료 {}",
+          authentication.getName());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * header가 null이거나, Bearer로 시작하는지 검증한다.
+   */
+  private boolean validateHeader(String header) {
+    return header != null && header.startsWith("Bearer ");
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/filter/JwtExceptionFilter.java
@@ -1,0 +1,31 @@
+package com.sesacthon.foreco.jwt.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sesacthon.foreco.jwt.exception.JwtException;
+import com.sesacthon.global.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      filterChain.doFilter(request, response);
+    } catch (JwtException e) {
+      response.setStatus(e.getErrorCode().getStatus());
+      response.setContentType("application/json");
+      response.setCharacterEncoding("UTF-8");
+      objectMapper.writeValue(response.getWriter(), ErrorResponse.of(e.getErrorCode()));
+    }
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenProvider.java
@@ -1,0 +1,150 @@
+package com.sesacthon.foreco.jwt.service;
+
+import com.sesacthon.foreco.jwt.dto.SessionUser;
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.entity.Role;
+import com.sesacthon.foreco.member.repository.MemberRepository;
+import com.sesacthon.infra.redis.RefreshToken;
+import com.sesacthon.infra.redis.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+/**
+ * 토큰 발급해주는 서비스(Jwt 도메인의 Service 라고 생각하는 것이 좋다)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+  private final MemberRepository memberRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  //  jwt를 생성해주는 secretKey
+  private static String secretKey = "MFswDQYJKoZIhvcNAQEBBQADSgAwRwJAaJd167MUifo3ZSytpDPd9z7oSS+1KXjf\n"
+      + "HJ3oMvI61Id26fdQHgWE1QMLcrhOmRzTxkCU+gesx5ANkSSIrPHNswIDAQAB";
+
+  //accessToken 만료시간
+  public static final Long ACCESS_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60 * 24; //1일
+
+  //refreshToken 만료시간
+  public static final Long REFRESH_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60 * 24 * 14; //2주
+
+  private Key key;
+
+  @PostConstruct
+  protected void init() {
+    secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+    key = Keys.hmacShaKeyFor(keyBytes);
+  }
+
+  //accessToken을 사용하여 Authentication 객체를 생성한다.
+  public Authentication getAuthentication(String accessToken) {
+    Claims claims = extractAllClaims(accessToken); //claims 정보를 추출할때 유효성 체크를 시작한다.
+    String role = claims.get("role").toString();
+    String uuid = claims.getSubject();
+    return new UsernamePasswordAuthenticationToken(getSessionUser(uuid), "",
+        getGrantedAuthorities(role));
+  }
+
+  private SessionUser getSessionUser(String uuid) {
+    UUID changeUuid = UUID.fromString(uuid);
+    log.info("session user 를 만들기 위해서 uuid : {} 인 사람을 찾습니다.", uuid);
+    Optional<Member> optionalMember = memberRepository.findById(changeUuid);
+
+    if (optionalMember.isEmpty()) {
+      throw new JwtException("유효하지 않은 토큰");
+    }
+    return new SessionUser(optionalMember.get());
+  }
+
+  private static List<GrantedAuthority> getGrantedAuthorities(String role) {
+    List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+    grantedAuthorities.add(new SimpleGrantedAuthority(role));
+    return grantedAuthorities;
+  }
+
+  /**
+   * 게스트로 진입할때, 해당 유저를 DB에 저장하고 난 후의 UUID로 accessToken을 생성한다.
+   * 유효시간은 1시간으로 설정해놓았다.
+   */
+  public String createAccessToken(UUID uuid, Role role) {
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH_MS);
+
+    return Jwts.builder()
+        .signWith(key, SignatureAlgorithm.HS256)
+        .setSubject(uuid.toString())
+        .claim("role", role.getAuthority())
+        .setIssuer("bbok")
+        .setIssuedAt(now)
+        .setExpiration(validity)
+        .compact();
+  }
+
+  /**
+   * Refresh Token 을 생성한다.
+   * 유효 시간은 14일로 설정한다.
+   * @return 생성된 Refresh Token
+   */
+  public String createRefreshToken(UUID memberId) {
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_LENGTH_MS);
+
+    String refreshToken = Jwts.builder()
+        .signWith(key, SignatureAlgorithm.HS256)
+        .setIssuer("bbok")
+        .setIssuedAt(now)
+        .setExpiration(validity)
+        .compact();
+
+    RefreshToken token = new RefreshToken(memberId, refreshToken);
+    refreshTokenRepository.save(token);
+    return refreshToken;
+  }
+
+  private Claims extractAllClaims(String token) {
+    try {
+      return Jwts.parserBuilder().setSigningKey(secretKey).build()
+          .parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+  public boolean isTokenExpirationSafe(String token) {
+    Instant expiration = extractAllClaims(token).getExpiration().toInstant();
+    Instant now = Instant.now();
+    return hasTokenExpMoreThanThreeDays(expiration, now);
+  }
+
+  private boolean hasTokenExpMoreThanThreeDays(Instant expiration, Instant now) {
+    return (Duration.between(now, expiration).compareTo(Duration.ofDays(3)) >= 0);
+  }
+
+  public void saveRefreshTokenInRedis(Member member, String refreshToken) {
+    refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken));
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenReissueService.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenReissueService.java
@@ -1,0 +1,38 @@
+package com.sesacthon.foreco.jwt.service;
+
+
+import com.sesacthon.foreco.jwt.dto.ReIssueTokenDto;
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.service.MemberService;
+import com.sesacthon.infra.redis.RedisService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 토큰을 재발행할 수 있는 서비스.
+ * refreshToken 이 3일이상 남으면 accessToken 만 발급합니다.
+ * refreshToken 만료기간이 3일보다 적게 남으면 accessToken과 refreshToken 모두 발급합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class JwtTokenReissueService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RedisService redisService;
+  private final MemberService memberService;
+
+  public ReIssueTokenDto reIssueToken(String refreshToken) {
+    UUID memberId = redisService.findMemberByToken(refreshToken);
+    Member member = memberService.getMemberById(memberId);
+    String newAccessToken = jwtTokenProvider.createAccessToken(memberId, member.getRole());
+
+    if(jwtTokenProvider.isTokenExpirationSafe(refreshToken)) {
+      return new ReIssueTokenDto(newAccessToken, refreshToken);
+    }
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+    redisService.saveRefreshToken(memberId, newRefreshToken);
+    return new ReIssueTokenDto(newAccessToken, newRefreshToken);
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
+++ b/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
@@ -69,17 +69,16 @@ public class MemberController {
   @Operation(
       summary = "카카오 계정 회원가입",
       description = "인가 코드를 입력하고 요청보내면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
-  @PostMapping("/api/v1/kakao/signup")
-  public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> kakaoLogin(@RequestParam("code") String code) {
+  @GetMapping("/api/v1/account/kakao/result")
+  public ResponseEntity<DataResponse<LoginResponseDto>> kakaoLogin(@RequestParam("code") String code) {
 
+    //TODO: 쿠키, 헤더 사용하지 않고 바로 accessToken과 refreshToken을 발급해주는 방식으로 바꿀 예정
     //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
     KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code);
     LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo);
-    HttpHeaders headers = setCookieAndHeader(kakaoLoginResponse);
-
     return new ResponseEntity<>(
         DataResponse.of(
-            HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse.getMember()), headers, HttpStatus.CREATED);
+            HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse), HttpStatus.CREATED);
   }
 
   /**

--- a/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
+++ b/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
@@ -1,0 +1,102 @@
+package com.sesacthon.foreco.member.controller;
+
+import static com.sesacthon.foreco.member.service.MemberSignUpService.setCookieAndHeader;
+
+import com.sesacthon.foreco.jwt.dto.SessionUser;
+import com.sesacthon.foreco.member.dto.response.LoginResponseDto;
+import com.sesacthon.foreco.member.dto.response.MemberInfoResponseDto;
+import com.sesacthon.foreco.member.dto.response.MemberSimpleInfoResponse;
+import com.sesacthon.foreco.member.service.MemberInfoService;
+import com.sesacthon.foreco.member.service.MemberSignUpService;
+import com.sesacthon.global.response.DataResponse;
+import com.sesacthon.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import com.sesacthon.infra.feign.service.KakaoFeignService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "멤버 관련 컨트롤러")
+public class MemberController {
+
+  private final KakaoFeignService kakaoFeignService;
+  private final MemberSignUpService memberSignUpService;
+  private final MemberInfoService memberInfoService;
+
+  /**
+   * 게스트 로그인 관련 컨트롤러
+   */
+  @Operation(
+      summary = "게스트 회원가입",
+      description = "요청 보내면 바로 게스트가 생성되고, accessToken이 발급됩니다.")
+  @PostMapping("/api/v1/guest/signup")
+  public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> guestLogin() {
+
+    LoginResponseDto guestLoginResponse = memberSignUpService.loginGuestMember();
+    HttpHeaders headers = setCookieAndHeader(guestLoginResponse);
+
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED,
+        "게스트 회원 가입 성공", guestLoginResponse.getMember()), headers, HttpStatus.CREATED);
+  }
+
+  /**
+   * 로그인 요청을 통해 인가코드를 redirect url로 발급 가능
+   */
+  @Operation(
+      summary = "인가 코드 발급",
+      description = "해당 url을 통해 로그인 화면으로 넘어간 후, 사용자가 정보를 입력하면 redirect url에서 코드를 발급할 수 있습니다.")
+  @GetMapping("/api/v1/kakao/login")
+  public ResponseEntity<HttpHeaders> getKakaoAuthCode()  {
+    HttpHeaders httpHeaders = kakaoFeignService.kakaoLogin();
+    return new ResponseEntity<>(httpHeaders, HttpStatus.SEE_OTHER);
+  }
+
+  /**
+   * 인가코드를 통해 accessToken 과 유저 정보를 가져온다.
+   */
+  @Operation(
+      summary = "카카오 계정 회원가입",
+      description = "인가 코드를 입력하고 요청보내면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
+  @PostMapping("/api/v1/kakao/signup")
+  public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> kakaoLogin(@RequestParam("code") String code) {
+
+    //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
+    KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code);
+    LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo);
+    HttpHeaders headers = setCookieAndHeader(kakaoLoginResponse);
+
+    return new ResponseEntity<>(
+        DataResponse.of(
+            HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse.getMember()), headers, HttpStatus.CREATED);
+  }
+
+  /**
+   * 유저가 자기 자신의 정보에 대해 알 수 있다.
+   */
+  @Operation(
+      summary = "내 정보 조회",
+      description = "마이 페이지에서 사용자의 정보를 볼 수 있습니다.")
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/api/v1/member")
+  public ResponseEntity<DataResponse<MemberInfoResponseDto>> getMember(
+      @AuthenticationPrincipal SessionUser sessionUser
+  ) {
+    MemberInfoResponseDto memberInfo = memberInfoService.getMember(sessionUser.getUuid());
+    return new ResponseEntity<>(
+        DataResponse.of(HttpStatus.OK, "멤버 정보 조회 성공", memberInfo), HttpStatus.OK);
+  }
+
+
+}

--- a/src/main/java/com/sesacthon/foreco/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/sesacthon/foreco/member/dto/response/LoginResponseDto.java
@@ -1,0 +1,24 @@
+package com.sesacthon.foreco.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class LoginResponseDto {
+
+  @Schema(description = "발급된 액세스 토큰")
+  private final String accessToken;
+
+  @Schema(description = "발급된 리프레쉬 토큰")
+  private final String refreshToken;
+
+  @Schema(description = "멤버의 id만 반환되는 dto")
+  private final MemberSimpleInfoResponse member;
+
+  public LoginResponseDto(String accessToken, String refreshToken, MemberSimpleInfoResponse member) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.member = member;
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/sesacthon/foreco/member/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,32 @@
+package com.sesacthon.foreco.member.dto.response;
+
+
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.entity.OAuth2Provider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+  @Schema(description = "member의 프로필 이미지 url")
+  private final String profileUrl;
+
+  @Schema(description = "member의 고유 Id")
+  private final String memberId;
+
+  @Schema(description = "member의 이름")
+  private final String memberName;
+
+  @Schema(description = "member의 oauth 제공자(GUEST, KAKAO)")
+  private final OAuth2Provider oauth2Provider;
+
+  public MemberInfoResponseDto(Member member) {
+    this.profileUrl = member.getProfileUrl();
+    this.memberId = member.getId().toString();
+    this.memberName =
+        member.getOauth2Provider().equals(OAuth2Provider.GUEST) ?
+        member.getUserNumber():member.getUsername();
+    this.oauth2Provider = member.getOauth2Provider();
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/member/dto/response/MemberSimpleInfoResponse.java
+++ b/src/main/java/com/sesacthon/foreco/member/dto/response/MemberSimpleInfoResponse.java
@@ -1,0 +1,17 @@
+package com.sesacthon.foreco.member.dto.response;
+
+import com.sesacthon.foreco.member.entity.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class MemberSimpleInfoResponse {
+
+  @Schema(description = "member의 고유 Id")
+  private final String memberId;
+
+  public MemberSimpleInfoResponse(Member member) {
+    this.memberId = member.getId().toString();
+  }
+
+}

--- a/src/main/java/com/sesacthon/foreco/member/entity/Member.java
+++ b/src/main/java/com/sesacthon/foreco/member/entity/Member.java
@@ -1,0 +1,78 @@
+package com.sesacthon.foreco.member.entity;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+import com.sesacthon.foreco.common.BaseTimeEntity;
+import jakarta.persistence.GenerationType;
+import java.util.UUID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(length = 16)
+  private UUID id;
+
+  /**
+   * 역할(Guest, Social)
+   */
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  /**
+   * 회원번호 (oauthProvider#회원번호)
+   * 게스트 로그인한 사용자의 이름을 나타내기 위해서 생성했습니다.
+   */
+  private String userNumber;
+
+  /**
+   * SNS 로그인한 사용자의 이름
+   * 게스트 로그인 사용자의 이름은 NONE으로 설정했습니다.
+   */
+  private String username;
+
+  /**
+   * profile 이미지 url
+   */
+  private String profileUrl;
+
+  /**
+   * OAuth 제공자
+   */
+  @Enumerated(EnumType.STRING)
+  private OAuth2Provider oauth2Provider;
+
+
+
+  @PrePersist
+  public void createId() {
+    this.id = UuidCreator.getTimeOrdered();
+  }
+
+  @Builder
+  public Member(String profileUrl, String userNumber,
+      Role role, OAuth2Provider oauth2Provider, String username) {
+    this.userNumber = userNumber;
+    this.username = username;
+    this.profileUrl = profileUrl;
+    this.role = role;
+    this.oauth2Provider = oauth2Provider;
+  }
+
+  public void updateInfo(String profileUrl, String username) {
+    this.profileUrl = profileUrl;
+    this.username = username;
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/member/entity/OAuth2Provider.java
+++ b/src/main/java/com/sesacthon/foreco/member/entity/OAuth2Provider.java
@@ -1,0 +1,10 @@
+package com.sesacthon.foreco.member.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OAuth2Provider {
+  KAKAO,
+  GUEST
+}
+

--- a/src/main/java/com/sesacthon/foreco/member/entity/Role.java
+++ b/src/main/java/com/sesacthon/foreco/member/entity/Role.java
@@ -1,0 +1,15 @@
+package com.sesacthon.foreco.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+  ROLE_GUEST("guest"),
+  ROLE_SOCIAL("social");
+
+  private final String authority;
+}
+

--- a/src/main/java/com/sesacthon/foreco/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/sesacthon/foreco/member/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.sesacthon.foreco.member.exception;
+
+import com.sesacthon.global.exception.BusinessException;
+import com.sesacthon.global.exception.ErrorCode;
+
+public class MemberNotFoundException extends BusinessException {
+  public MemberNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/member/repository/MemberRepository.java
+++ b/src/main/java/com/sesacthon/foreco/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.sesacthon.foreco.member.repository;
+
+import com.sesacthon.foreco.member.entity.Member;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+
+  @Query("select m from Member m where m.id = :id")
+  Optional<Member> findById(@Param("id")UUID uuid);
+
+  @Query("select m from Member m where m.userNumber = :username")
+  Optional<Member> findByUsername(@Param("username") String username);
+}

--- a/src/main/java/com/sesacthon/foreco/member/service/MemberInfoService.java
+++ b/src/main/java/com/sesacthon/foreco/member/service/MemberInfoService.java
@@ -1,0 +1,19 @@
+package com.sesacthon.foreco.member.service;
+
+import com.sesacthon.foreco.member.dto.response.MemberInfoResponseDto;
+import com.sesacthon.foreco.member.entity.Member;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoService {
+
+  private final MemberService memberService;
+
+  public MemberInfoResponseDto getMember(UUID memberId) {
+    Member member = memberService.getMemberById(memberId);
+    return new MemberInfoResponseDto(member);
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/member/service/MemberService.java
+++ b/src/main/java/com/sesacthon/foreco/member/service/MemberService.java
@@ -1,0 +1,51 @@
+package com.sesacthon.foreco.member.service;
+
+import static com.sesacthon.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.entity.OAuth2Provider;
+import com.sesacthon.foreco.member.entity.Role;
+import com.sesacthon.foreco.member.exception.MemberNotFoundException;
+import com.sesacthon.foreco.member.repository.MemberRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+  private final MemberRepository memberRepository;
+
+  public Member saveGuestMember() {
+    return memberRepository.save(createGuestMember());
+  }
+
+  private Member createGuestMember() {
+    return Member.builder()
+        .userNumber(
+            String.format("%s#%s", OAuth2Provider.GUEST, UUID.randomUUID().toString().split("-")[0])
+        )
+        .username("NONE")
+        .role(Role.ROLE_GUEST)
+        .profileUrl("https://i.ibb.co/34SNTwm/image.png")
+        .oauth2Provider(OAuth2Provider.GUEST)
+        .build();
+  }
+
+  public Optional<Member> getMemberByUserNumber(String username) {
+    return memberRepository.findByUsername(username);
+  }
+
+  public Member saveInfo(Member member) {
+    return memberRepository.save(member);
+  }
+
+  public Member getMemberById(UUID uuid) {
+    log.info("해당 uuid를 가진 멤버를 찾습니다.");
+    return memberRepository.findById(uuid)
+        .orElseThrow(()->new MemberNotFoundException(MEMBER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/member/service/MemberSignUpService.java
+++ b/src/main/java/com/sesacthon/foreco/member/service/MemberSignUpService.java
@@ -1,0 +1,84 @@
+package com.sesacthon.foreco.member.service;
+
+import com.sesacthon.foreco.jwt.dto.ReIssueTokenDto;
+import com.sesacthon.foreco.jwt.service.JwtTokenProvider;
+import com.sesacthon.foreco.member.dto.response.LoginResponseDto;
+import com.sesacthon.foreco.member.dto.response.MemberSimpleInfoResponse;
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.entity.OAuth2Provider;
+import com.sesacthon.global.util.CookieUtil;
+import com.sesacthon.global.util.HttpHeaderUtil;
+import com.sesacthon.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberSignUpService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final MemberService memberService;
+
+  public LoginResponseDto loginGuestMember() {
+    Member guest = memberService.saveGuestMember();
+    return createSignUpResult(guest);
+  }
+
+  public LoginResponseDto loginKakaoMember(KakaoUserInfoResponseDto kakaoUserInfo) {
+    //카카오 회원 Id를 변조해서 검사해본다.(회원 Id로 해야만 고유성을 가질 수 있기 때문에)
+    String userNumber = String.format("%s#%s", OAuth2Provider.KAKAO, kakaoUserInfo.getId());
+    Optional<Member> loginMember = memberService.getMemberByUserNumber(userNumber);
+
+    //만약 존재한다면, update 친다.
+    if(loginMember.isPresent()) {
+      Member member = loginMember.get();
+      updateMemberInfo(kakaoUserInfo, member);
+      //토큰 새로 생성이 아닌, 이후에 refreshToken 체크해서 accessToken을 다시 발급해주는 로직을 넣어야 함.
+      return createSignUpResult(member);
+    }
+
+    //존재하지 않는다면, user를 생성해서 넣어준다.
+    Member member = signUp(kakaoUserInfo);
+    return createSignUpResult(member);
+  }
+
+  /**
+   * member 정보를 가지고 accessToken 과 refreshToken 을 생성한다.
+   */
+  private LoginResponseDto createSignUpResult(Member member) {
+    String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+    // refreshToken은 redis에 따로 저장해둔다.
+    jwtTokenProvider.saveRefreshTokenInRedis(member, refreshToken);
+    return new LoginResponseDto(accessToken, refreshToken, new MemberSimpleInfoResponse(member));
+  }
+
+  private Member signUp(KakaoUserInfoResponseDto kakaoUserInfo) {
+    Member member = kakaoUserInfo.toEntity();
+    return memberService.saveInfo(member);
+  }
+
+  private void updateMemberInfo(KakaoUserInfoResponseDto kakaoUserInfo, Member member) {
+    member.updateInfo(kakaoUserInfo.getProfileImg(), kakaoUserInfo.getUsername());
+  }
+
+  public static HttpHeaders setCookieAndHeader(LoginResponseDto loginResult) {
+    HttpHeaders headers = new HttpHeaders();
+    CookieUtil.setRefreshCookie(headers, loginResult.getRefreshToken());
+    HttpHeaderUtil.setAccessToken(headers, loginResult.getAccessToken());
+    return headers;
+  }
+
+  public static HttpHeaders setCookieAndHeader(ReIssueTokenDto reIssueTokenDto) {
+    HttpHeaders headers = new HttpHeaders();
+    HttpHeaderUtil.setAccessToken(headers, reIssueTokenDto.getAccessToken());
+    CookieUtil.setRefreshCookie(headers, reIssueTokenDto.getRefreshToken());
+    return headers;
+  }
+
+}

--- a/src/main/java/com/sesacthon/global/exception/ErrorCode.java
+++ b/src/main/java/com/sesacthon/global/exception/ErrorCode.java
@@ -15,6 +15,15 @@ public enum ErrorCode {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 에러"),
   INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "입력 값의 타입이 올바르지 않습니다."),
   HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근이 거부 되었습니다."),
+  RESOURCE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C006", "인증이 필요합니다. 로그인을 해주세요."),
+  RESOURCE_FORBIDDEN(HttpStatus.FORBIDDEN, "C007", "해당 리소스에 대한 권한이 없습니다."),
+
+  // Member
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 uuid를 가진 멤버를 찾을 수 없습니다."),
+
+  // JWT
+  REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다."),
+
 
   /**
    * 도메인(entity)에 따른 에러코드 - 추가 예정

--- a/src/main/java/com/sesacthon/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/sesacthon/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.sesacthon.global.security;
+
+import static com.sesacthon.global.exception.ErrorCode.RESOURCE_FORBIDDEN;
+
+import com.sesacthon.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType("application/json;charset=UTF-8");
+    objectMapper.writeValue(response.getWriter(), ErrorResponse.of(RESOURCE_FORBIDDEN));
+  }
+}

--- a/src/main/java/com/sesacthon/global/security/SecurityConfig.java
+++ b/src/main/java/com/sesacthon/global/security/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.sesacthon.global.security;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import com.sesacthon.foreco.jwt.filter.JwtAuthenticationEntryPointHandler;
+import com.sesacthon.foreco.jwt.filter.JwtAuthenticationFilter;
+import com.sesacthon.foreco.jwt.filter.JwtExceptionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtExceptionFilter jwtExceptionFilter;
+  private final JwtAuthenticationEntryPointHandler jwtAuthenticationEntryPointHandler;
+  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(AbstractHttpConfigurer::disable)
+        .sessionManagement(session ->
+            session.sessionCreationPolicy(STATELESS))
+        .authorizeHttpRequests(authorize ->
+            authorize.requestMatchers(HttpMethod.GET, "/api/v1/member").authenticated()
+                     .requestMatchers("/**").permitAll())
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+
+    http.exceptionHandling(exception ->
+        exception.authenticationEntryPoint(jwtAuthenticationEntryPointHandler)
+            .accessDeniedHandler(jwtAccessDeniedHandler));
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/sesacthon/global/util/CookieUtil.java
+++ b/src/main/java/com/sesacthon/global/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package com.sesacthon.global.util;
+
+import static com.sesacthon.foreco.jwt.service.JwtTokenProvider.REFRESH_TOKEN_EXPIRE_LENGTH_MS;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+
+/**
+ * Cookie 관련 유틸리티 클래스.
+ */
+public class CookieUtil {
+
+  private CookieUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static void setRefreshCookie(HttpHeaders httpHeaders, String refreshToken) {
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(true)
+        .maxAge(REFRESH_TOKEN_EXPIRE_LENGTH_MS)
+        .path("/")
+        .sameSite("None")
+        .build();
+
+    httpHeaders.add(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+}

--- a/src/main/java/com/sesacthon/global/util/HttpHeaderUtil.java
+++ b/src/main/java/com/sesacthon/global/util/HttpHeaderUtil.java
@@ -1,0 +1,19 @@
+package com.sesacthon.global.util;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * access Token 을 Header 의 Authorization 에 담는다.
+ */
+public class HttpHeaderUtil {
+
+  private HttpHeaderUtil() {
+  }
+
+  public static void setAccessToken(HttpHeaders headers, String accessToken) {
+    // set access token header
+    headers.set(AUTHORIZATION, "Bearer " + accessToken);
+  }
+}

--- a/src/main/java/com/sesacthon/infra/feign/client/KakaoInfoClient.java
+++ b/src/main/java/com/sesacthon/infra/feign/client/KakaoInfoClient.java
@@ -1,0 +1,21 @@
+package com.sesacthon.infra.feign.client;
+
+import com.sesacthon.infra.feign.config.KakaoFeignConfig;
+import com.sesacthon.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/**
+ * 카카오 사용자 정보 얻어오는 feign client
+ */
+@FeignClient(name = "kakaoInfoClient", url = "https://kapi.kakao.com", configuration = KakaoFeignConfig.class)
+@Component
+public interface KakaoInfoClient {
+
+  //https://kapi.kakao.com/v2/user/me => 회원 정보 요청 url
+  @GetMapping(value = "/v2/user/me")
+  KakaoUserInfoResponseDto getUserInfo(@RequestHeader(name = "Authorization") String Authorization);
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/client/KakaoTokenClient.java
+++ b/src/main/java/com/sesacthon/infra/feign/client/KakaoTokenClient.java
@@ -1,0 +1,21 @@
+package com.sesacthon.infra.feign.client;
+
+import com.sesacthon.infra.feign.config.KakaoFeignConfig;
+import com.sesacthon.infra.feign.dto.response.KakaoTokenResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 카카오 토큰 관련 feign client
+ */
+@FeignClient(name = "kakaoTokenClient", url = "https://kauth.kakao.com", configuration = KakaoFeignConfig.class)
+@Component
+public interface KakaoTokenClient {
+
+  //https://kauth.kakao.com/oauth/token => 카카오 토큰 받기 url
+  @PostMapping(value = "/oauth/token")
+  KakaoTokenResponseDto getToken(@RequestBody String kakaoTokenRequestDto);
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/config/KakaoFeignConfig.java
+++ b/src/main/java/com/sesacthon/infra/feign/config/KakaoFeignConfig.java
@@ -1,0 +1,28 @@
+package com.sesacthon.infra.feign.config;
+
+import feign.Logger;
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.sesacthon.infra")
+public class KakaoFeignConfig {
+
+  @Bean
+  Logger.Level feignLoggerLevel() {
+    return Logger.Level.FULL;
+  }
+
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+    return template -> template.header("Content-Type", "application/x-www-form-urlencoded");
+  }
+
+//  @Bean
+//  public ErrorDecoder errorDecoder() {
+//    return new FeignClientExceptionErrorDecoder();
+//  }
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/dto/KakaoInfo.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/KakaoInfo.java
@@ -1,0 +1,43 @@
+package com.sesacthon.infra.feign.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * yml 정보를 잇는 클래스
+ */
+@Slf4j
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth2.kakao")
+public class KakaoInfo {
+
+  private String baseUrl;
+  private String clientId;
+  private String redirectUri;
+  private String secretKey;
+
+  public String kakaoUrlInit() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("redirect_uri", getRedirectUri());
+    params.put("client_id", getClientId());
+    params.put("response_type", "code");
+
+    String paramStr = params.entrySet().stream()
+        .map(param -> param.getKey() + "=" + param.getValue())
+        .collect(Collectors.joining("&"));
+
+    return getBaseUrl()
+        +"/oauth/authorize"
+        + "?"
+        + paramStr;
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/dto/request/KakaoTokenRequestDto.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/request/KakaoTokenRequestDto.java
@@ -1,0 +1,44 @@
+package com.sesacthon.infra.feign.dto.request;
+
+import com.sesacthon.infra.feign.dto.KakaoInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 액세스 토큰을 얻기 위한 request Dto
+ * 액세스 토큰을 얻어야만 사용자 정보를 가져올 수 있다.
+ */
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class KakaoTokenRequestDto {
+
+  private String code;
+  private String client_id;
+  private String client_secret;
+  private String redirect_uri;
+  private final String grant_type = "authorization_code";
+
+  public static KakaoTokenRequestDto newInstance(KakaoInfo kakaoInfo, String code) {
+    return KakaoTokenRequestDto.builder()
+        .client_id(kakaoInfo.getClientId())
+        .client_secret(kakaoInfo.getSecretKey())
+        .redirect_uri(kakaoInfo.getRedirectUri())
+        .code(code)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return
+        "code=" + code + '&' +
+            "client_id=" + client_id + '&' +
+            "client_secret=" + client_secret + '&' +
+            "redirect_uri=" + redirect_uri + '&' +
+            "grant_type=" + grant_type;
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/dto/response/KakaoTokenResponseDto.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/response/KakaoTokenResponseDto.java
@@ -1,0 +1,45 @@
+package com.sesacthon.infra.feign.dto.response;
+
+import lombok.Getter;
+
+/**
+ * 카카오 액세스 토큰 정보 응답 Dto
+ */
+@Getter
+public class KakaoTokenResponseDto {
+
+  /**
+   * 반환되는 토큰 타입(Bearer 고정)
+   */
+  private String token_type;
+
+  /**
+   * 사용자의 accessToken 값
+   */
+  private String access_token;
+
+  /**
+   * accessToken 만료 시간
+   */
+  private String expires_in;
+
+  /**
+   * 사용자의 refreshToken 값
+   */
+  private String refresh_token;
+
+  /**
+   * refreshToken 만료 시간
+   */
+  private String refresh_token_expires_in;
+
+  public String getAccessToken() {
+    return "Bearer " + access_token;
+  }
+
+  @Override
+  public String toString() {
+    return "액세스 토큰입니다: " + access_token;
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/dto/response/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/response/KakaoUserInfoResponseDto.java
@@ -1,0 +1,66 @@
+package com.sesacthon.infra.feign.dto.response;
+
+import com.sesacthon.foreco.member.entity.Member;
+import com.sesacthon.foreco.member.entity.OAuth2Provider;
+import com.sesacthon.foreco.member.entity.Role;
+import lombok.Getter;
+
+/**
+ * 카카오 서버에서 어떤 정보를 가져올지
+ */
+@Getter
+public class KakaoUserInfoResponseDto {
+
+  /**
+   * 회원 번호
+   */
+  private Long id;
+
+  /**
+   * 카카오 계정 정보
+   */
+  private KakaoAccount kakao_account;
+
+  @Getter
+  static class KakaoAccount {
+    private Profile profile;
+  }
+
+  @Getter
+  static class Profile {
+    private String nickname;
+    private String profile_image_url;
+  }
+
+  @Override
+  public String toString() {
+    return
+        "id = " + this.id +
+        "profile.nickname = " + this.kakao_account.profile.nickname +
+            "profile.profile_img_url = " + this.kakao_account.profile.profile_image_url;
+  }
+
+  public String getProfileImg() {
+    return this.getKakao_account().getProfile().profile_image_url;
+  }
+
+  public String getUsername() {
+    return this.getKakao_account().getProfile().getNickname();
+  }
+
+  public String createUserNumber() {
+    return String.format("%s#%s", OAuth2Provider.KAKAO, this.getId());
+  }
+
+  public Member toEntity() {
+    return Member.builder()
+        .username(this.getUsername())
+        .userNumber(createUserNumber())
+        .role(Role.ROLE_SOCIAL)
+        .oauth2Provider(OAuth2Provider.KAKAO)
+        .profileUrl(this.getProfileImg())
+        .build();
+  }
+
+
+}

--- a/src/main/java/com/sesacthon/infra/feign/service/KakaoFeignService.java
+++ b/src/main/java/com/sesacthon/infra/feign/service/KakaoFeignService.java
@@ -1,0 +1,72 @@
+package com.sesacthon.infra.feign.service;
+
+import com.sesacthon.infra.feign.client.KakaoInfoClient;
+import com.sesacthon.infra.feign.client.KakaoTokenClient;
+import com.sesacthon.infra.feign.dto.KakaoInfo;
+import com.sesacthon.infra.feign.dto.request.KakaoTokenRequestDto;
+import com.sesacthon.infra.feign.dto.response.KakaoTokenResponseDto;
+import com.sesacthon.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoFeignService {
+
+  private final KakaoTokenClient kakaoTokenClient;
+  private final KakaoInfoClient kakaoInfoClient;
+  private final KakaoInfo kakaoInfo;
+
+  public HttpHeaders kakaoLogin(){
+    return createHttpHeader(kakaoInfo.kakaoUrlInit());
+  }
+
+  private static HttpHeaders createHttpHeader(String requestUrl) {
+    try {
+      URI uri = new URI(requestUrl);
+      HttpHeaders httpHeaders = new HttpHeaders();
+      httpHeaders.setLocation(uri);
+      return httpHeaders;
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  /**
+   * 인가 코드를 가지고 토큰을 가져옵니다.
+   * @param code 카카오 서버에서 내려준 인가 코드
+   * @return 해당 사용자 정보 response dto
+   */
+  public KakaoUserInfoResponseDto getKakaoInfoWithToken(String code) {
+    //1. 인가 코드를 가지고 토큰을 가져온다.
+    String kakaoToken = getKakaoToken(code);
+    //2. 해당 토큰으로 user 정보를 들고온다.
+    return getKakaoInfo(kakaoToken);
+  }
+
+  /**
+   * 카카오 액세스 토큰으로 유저 정보를 요청합니다.
+   */
+  private KakaoUserInfoResponseDto getKakaoInfo(String kakaoToken) {
+    return kakaoInfoClient.getUserInfo(kakaoToken);
+  }
+
+  /**
+   * 인가 코드를 가지고 토큰을 가져옵니다.
+   * @param code 서버에서 내려주는 인가코드.
+   * @return accessToken
+   */
+  private String getKakaoToken(String code) {
+    KakaoTokenResponseDto token = kakaoTokenClient.getToken(
+        KakaoTokenRequestDto.newInstance(kakaoInfo, code).toString());
+    return token.getAccessToken();
+  }
+
+
+}

--- a/src/main/java/com/sesacthon/infra/redis/RedisService.java
+++ b/src/main/java/com/sesacthon/infra/redis/RedisService.java
@@ -1,0 +1,31 @@
+package com.sesacthon.infra.redis;
+
+import static com.sesacthon.global.exception.ErrorCode.REFRESH_JWT_EXPIRED;
+
+import com.sesacthon.foreco.jwt.exception.JwtException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * refreshToken 관리를 위한 Redis 관련 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Transactional
+  public void saveRefreshToken(UUID memberId, String refreshToken) {
+    refreshTokenRepository.save(new RefreshToken(memberId, refreshToken));
+  }
+
+  @Transactional(readOnly = true)
+  public UUID findMemberByToken(String refreshToken) {
+    RefreshToken token = refreshTokenRepository.findByRefreshToken(refreshToken)
+        .orElseThrow(() -> new JwtException(REFRESH_JWT_EXPIRED));
+    return token.getMemberId();
+  }
+}

--- a/src/main/java/com/sesacthon/infra/redis/RefreshToken.java
+++ b/src/main/java/com/sesacthon/infra/redis/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.sesacthon.infra.redis;
+
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "refreshToken", timeToLive = 1000L * 60 * 60 * 24 * 14)
+@Getter
+public class RefreshToken {
+
+  /**
+   * 사용자의 Id
+   */
+  @Id
+  private final UUID memberId;
+
+  /**
+   * 사용자가 가지고 있는 refreshToken
+   */
+  @Indexed
+  private final String refreshToken;
+
+  public RefreshToken(UUID memberId, String refreshToken) {
+    this.memberId = memberId;
+    this.refreshToken = refreshToken;
+  }
+
+}

--- a/src/main/java/com/sesacthon/infra/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/sesacthon/infra/redis/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.sesacthon.infra.redis;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.repository.CrudRepository;
+
+@EnableRedisRepositories
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
+
+  Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,6 +56,12 @@ logging:
           descriptor:
             sql: trace
         SQL: debug
-server:
-  port: 8081
+
+oauth2:
+  kakao:
+    infoUrl: https://kapi.kakao.com
+    baseUrl: https://kauth.kakao.com
+    clientId: dd6c51dc02204dacd84d70e52a877d8f
+    redirectUri: http://localhost:8080/api/v1/account/kakao/result
+    secretKey: ${SECRET_KEY}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -62,6 +62,7 @@ oauth2:
     infoUrl: https://kapi.kakao.com
     baseUrl: https://kauth.kakao.com
     clientId: dd6c51dc02204dacd84d70e52a877d8f
+    #TODO: 실제 배포 도메인 주소로 바꿔야 함
     redirectUri: http://localhost:8080/api/v1/account/kakao/result
     secretKey: ${SECRET_KEY}
 

--- a/src/main/resources/redis-server.yml
+++ b/src/main/resources/redis-server.yml
@@ -1,0 +1,13 @@
+# redis-server.yml
+version: '7.0.12'
+services:
+  redis:
+    image: redis:alpine
+    command: redis-server --port 6379
+    container_name: redis_docker
+    hostname: redis_docker
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - 6379:6379


### PR DESCRIPTION
### ✒️ 관련 이슈번호
소셜 연동 로그인과 게스트 로그인 기능을 구현했습니다.
- Close #72 

## 🔑 Key Changes
1. 다른 테이블과 달리 Member 테이블의 고유 식별자는 UUID입니다.
2. UUID로 access token(expire: 1일)과 refresh token(expire: 14일)을 발급받고 있습니다.

## 📢 To Reviewers
- 요구사항이 구체화되지 않아 기능이 수정될 수 있습니다!
- redis를 현재 사용하고 있기 때문에 PR이 올려지고 나서 프로젝트를 동작시키려면 redis(refresh Token 저장소)를 실행시켜야 합니다.
`docker-compose -f ./redis-server.yml up -d` 로 로컬에서 도커로 레디스를 띄울 수 있습니다! 