### PR TITLE
feat:관련쓰레기조회 api 구현

### DIFF
--- a/src/main/java/com/sesacthon/foreco/category/entity/Trash.java
+++ b/src/main/java/com/sesacthon/foreco/category/entity/Trash.java
@@ -47,15 +47,14 @@ public class Trash {
   private String trashIcon;
 
   /**
-   * 상위 카테고리 Id.
-   * 해당 데이터가 상위 카테고리라면 null
+   * 상위 카테고리 Id. 해당 데이터가 상위 카테고리라면 null
    */
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "trash_id")
   private Trash parentTrash;
 
   @OneToMany(mappedBy = "parentTrash")
-  private List<Trash> childCategories;
+  private List<Trash> childTrashes;
 
   /**
    * 배출정보(trashInfo)
@@ -67,5 +66,5 @@ public class Trash {
    * 지역 카테고리(RegionCategory)
    */
   @OneToMany(mappedBy = "trash")
-  List<RegionCategory> regionCategories= new ArrayList<RegionCategory>();
+  List<RegionCategory> regionCategories = new ArrayList<RegionCategory>();
 }

--- a/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
+++ b/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
@@ -4,5 +4,5 @@ import com.sesacthon.foreco.category.entity.Trash;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrashRepository extends JpaRepository<Trash, Long> {
-
+  
 }

--- a/src/main/java/com/sesacthon/foreco/trash/controller/TrashController.java
+++ b/src/main/java/com/sesacthon/foreco/trash/controller/TrashController.java
@@ -1,8 +1,16 @@
 package com.sesacthon.foreco.trash.controller;
 
+import com.sesacthon.foreco.mock.dto.TrashDetailDto;
+import com.sesacthon.foreco.trash.dto.RelevantTrashesDto;
+import com.sesacthon.foreco.trash.service.TrashService;
+import com.sesacthon.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,18 +18,30 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "쓰레기 세부품목", description = "세부품목 관련 api")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class TrashController {
 
-  @Operation(summary = "세부 품목 쓰레기 정보", description = "지역 기반 쓰레기 배출 정보를 조회할 수 있습니다.")
-  @GetMapping("/api/v1/trash")
-  public String getTrashInfoWithRegionCond(
-      @RequestParam("name") String name) {
-    return "ok";
+  private final TrashService trashService;
+  private static final Long REGION_ID = 1L; //지역이 현재 동대문구 전농1동이므로 고정하여 작업함.
+
+//  @Operation(summary = "쓰레기 상세 조회 API", description = "쓰레기 상세조회 API 입니다.")
+//  @GetMapping("/api/v1/trash/detail")
+//  public ResponseEntity<DataResponse<TrashDetailDto>> getTrashDetails(@RequestParam("id") Long id){
+//
+//    TrashDetailDto response = trashService.getTrashDetail(id,REGION_ID);
+//    return new ResponseEntity<>(
+//        DataResponse.of(HttpStatus.OK, "detailType=map, 쓰레기 상세조회 성공", response), HttpStatus.OK);
+//  }
+
+
+  @Operation(summary = "쓰레기 상세 조회시 필요한, 관련된 쓰레기 정보 조회API", description = "쓰레기 상세조회 화면에서 제공되야할 관련된 쓰레기들 입니다.")
+  @GetMapping("api/v1/trash/relation")
+  public ResponseEntity<DataResponse<RelevantTrashesDto>> getRelevantTrashes(
+      @Parameter(description = "조회할 쓰레기 id(숫자)") @RequestParam("id") Long id
+  ) {
+    RelevantTrashesDto response = trashService.getRelevantTrashes(id, REGION_ID);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "관련(추천) 쓰레기 정보 조회 성공", response),
+        HttpStatus.OK);
   }
 
-  @Operation(summary = "관련 쓰레기 정보", description = "관련된 쓰레기들의 정보를 조회할 수 있습니다.")
-  @GetMapping("api/v1/trash/relation")
-  public String getRelationTrashInfo(@RequestParam("name") String name) {
-    return "ok";
-  }
 }

--- a/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashDto.java
+++ b/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashDto.java
@@ -1,0 +1,18 @@
+package com.sesacthon.foreco.trash.dto;
+
+
+import lombok.Getter;
+
+@Getter
+public class RelevantTrashDto {
+
+  private final Long id;
+  private final String name;
+  private final String iconUrl;
+
+  public RelevantTrashDto(Long id, String name, String iconUrl) {
+    this.id = id;
+    this.name = name;
+    this.iconUrl = iconUrl;
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashesDto.java
+++ b/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashesDto.java
@@ -1,0 +1,21 @@
+package com.sesacthon.foreco.trash.dto;
+
+import com.sesacthon.foreco.category.entity.Trash;
+import com.sesacthon.foreco.trash.entity.TrashInfo;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class RelevantTrashesDto {
+
+  private final List<RelevantTrashDto> recommendTrashes;
+
+
+  public RelevantTrashesDto(List<TrashInfo> trashInfos){
+    this.recommendTrashes = trashInfos.stream().map((trashInfo)->{
+      Trash trash = trashInfo.getTrash();
+     return new RelevantTrashDto(trash.getId(), trash.getName(), trash.getTrashIcon());
+    }).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/trash/entity/TrashInfo.java
+++ b/src/main/java/com/sesacthon/foreco/trash/entity/TrashInfo.java
@@ -34,10 +34,10 @@ public class TrashInfo {
   private String method;
 
   /**
-   * 쓰레기 처리형태 (=detail type)
+   * 쓰레기 처리형태
    */
-  @Convert(converter = DisposalTypeConverter.class)
-  private DisposalType disposalType;
+//  @Convert(converter = DisposalTypeConverter.class)
+//  private DisposalType disposalType;
 
   /**
    * 쓰레기 카테고리

--- a/src/main/java/com/sesacthon/foreco/trash/repository/TrashInfoRepository.java
+++ b/src/main/java/com/sesacthon/foreco/trash/repository/TrashInfoRepository.java
@@ -1,10 +1,16 @@
 package com.sesacthon.foreco.trash.repository;
 
 import com.sesacthon.foreco.trash.entity.TrashInfo;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TrashInfoRepository extends JpaRepository<TrashInfo, Long> {
 
+  Optional<TrashInfo> findByTrashIdAndRegionId(Long trashId, Long regionId);
 }

--- a/src/main/java/com/sesacthon/foreco/trash/service/TrashService.java
+++ b/src/main/java/com/sesacthon/foreco/trash/service/TrashService.java
@@ -1,9 +1,20 @@
 package com.sesacthon.foreco.trash.service;
 
+import com.sesacthon.foreco.category.entity.Trash;
+import com.sesacthon.foreco.category.repository.TrashRepository;
 import com.sesacthon.foreco.disposal.repository.DisposalRepository;
-import com.sesacthon.foreco.region.service.RegionService;
+
+import com.sesacthon.foreco.mock.dto.TrashDetailDto;
+import com.sesacthon.foreco.trash.dto.RelevantTrashesDto;
+import com.sesacthon.foreco.trash.entity.TrashInfo;
+import com.sesacthon.foreco.trash.exception.RelatedTrashNotFoundException;
+import com.sesacthon.foreco.trash.exception.TrashNotFoundException;
 import com.sesacthon.foreco.trash.repository.TrashInfoRepository;
 
+import com.sesacthon.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,24 +26,38 @@ public class TrashService {
 
   private final TrashInfoRepository trashInfoRepository;
   private final DisposalRepository disposalRepository;
-  private final RegionService regionService;
+  private final TrashRepository trashRepository;
 
-//  public RelevantTrashesDto findRelevantTrash(String region, String trashName, int tab) {
-//
-////    //지역 id
-////    Long regionId = regionService.findRegion(region);
-////    //category id
-////    TrashInfo trashInfo = trashRepository.findTrashByRegionAndName(regionId, trashName, tab)
-////        .orElseThrow(() -> new TrashNotFoundException(TRASH_NOT_FOUND));
-////    Long categoryId = trashInfo.getTrash().getId();
-////    //관련쓰레기 정보
-////    List<TrashInfo> trashInfos = trashRepository.findTrashByRegionIdAndCategoryId(regionId, categoryId,
-////        trashName);
-////    //빈 List인 경우 error발생
-////    if (trashInfos.isEmpty()) {
-////      throw new RelatedTrashNotFoundException(RELATED_TRASH_NOT_FOUND);
-////    }
-////
-////    return new RelevantTrashesDto(trashInfos);
+
+  public RelevantTrashesDto getRelevantTrashes(Long id, Long regionId) {
+    //현재 쓰레기를 가져옴
+    Trash currentTrash = trashRepository.findById(id).orElseThrow(() -> new TrashNotFoundException(
+        ErrorCode.TRASH_NOT_FOUND));
+
+    //현재 쓰레기의 카테고리(부모)를 구함.
+    Trash categoryTrash = currentTrash.getParentTrash();
+    //부모 카테고리에 속해있는 연관쓰레기(자식)를 구함
+    List<Trash> childTrashes = categoryTrash.getChildTrashes();
+    childTrashes.remove(currentTrash); //현재 조회중인 trash 제외
+
+    //아무런 연관쓰레기가 없을 시, 에러처리
+    if (childTrashes.isEmpty()) {
+      throw new RelatedTrashNotFoundException(ErrorCode.RELATED_TRASH_NOT_FOUND);
+    }
+
+    List<TrashInfo> trashInfos = new ArrayList<>();
+    for (Trash childTrash : childTrashes) {
+      Optional<TrashInfo> trashInfo = trashInfoRepository.findByTrashIdAndRegionId(
+          childTrash.getId(), regionId);
+      trashInfo.ifPresent(trashInfos::add);
+    }
+
+    return new RelevantTrashesDto(trashInfos);
+  }
+
+//  public TrashDetailDto getTrashDetail(Long id, Long regionId) {
+//    Optional<TrashInfo> trashInfo = trashInfoRepository.findByIdAndRegionId(id,regionId);
+//    log.info("trashInfo{}",trashInfo.get().getId());
+//    return null;
 //  }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,7 +24,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- #84 84

## 🔑 Key Changes

1. 쓰레기 상세조회페이지에서 제공할, 관련 쓰레기 조회api입니다.

## 📢 To Reviewers

- api에 필요한 파라미터는 id이고, 지역은 우선 동대문구 전농1동으로 생각하고 로직을 구현했습니다.