### PR TITLE
refactor: /api/v1/image api응답 데이터에 id필드 추가

### DIFF
--- a/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
+++ b/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
@@ -13,6 +13,6 @@ public interface TrashRepository extends JpaRepository<Trash, Long> {
   List<Trash> searchTrashWithKeyword(
       @Param("categoryId") Long categoryId, @Param("keyword") String keyword);
 
-  //keyword와 동일한 name을 가지고 있으며, parentTrash가  null이 아닌 경우를 찾음.
-  Optional<Trash> findByNameAndParentTrashIsNotNull(String keyword);
+  //keyword를 포함한 name이며, parentTrash가  null이 아닌 경우를 찾음.
+  Optional<Trash> findByNameContainingAndParentTrashIsNotNull(String keyword);
 }

--- a/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
+++ b/src/main/java/com/sesacthon/foreco/category/repository/TrashRepository.java
@@ -2,6 +2,7 @@ package com.sesacthon.foreco.category.repository;
 
 import com.sesacthon.foreco.category.entity.Trash;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,4 +13,6 @@ public interface TrashRepository extends JpaRepository<Trash, Long> {
   List<Trash> searchTrashWithKeyword(
       @Param("categoryId") Long categoryId, @Param("keyword") String keyword);
 
+  //keyword와 동일한 name을 가지고 있으며, parentTrash가  null이 아닌 경우를 찾음.
+  Optional<Trash> findByNameAndParentTrashIsNotNull(String keyword);
 }

--- a/src/main/java/com/sesacthon/infra/s3/dto/UploadDto.java
+++ b/src/main/java/com/sesacthon/infra/s3/dto/UploadDto.java
@@ -7,10 +7,12 @@ public class UploadDto {
 
   private final String message;
   private final String result;
+  private final Long id;
 
-  public UploadDto(String message, String result) {
+  public UploadDto(String message, String result, Long id) {
     this.message = message;
     this.result = (result == null) ? "인식할 수 없음" : result;
+    this.id = id;
   }
 
 }

--- a/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
+++ b/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sesacthon.foreco.category.entity.Trash;
+import com.sesacthon.foreco.category.repository.TrashRepository;
 import com.sesacthon.infra.s3.dto.UploadDto;
 import com.sesacthon.infra.s3.exception.ImageUploadException;
 import java.io.BufferedReader;
@@ -18,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +34,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class S3Uploader {
 
   private final AmazonS3Client amazonS3Client;
+
+  private final TrashRepository trashRepository;
 
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
@@ -63,7 +68,7 @@ public class S3Uploader {
    * @param fileName createFileName 메서드를 통해서 변경된 파일 이름
    */
   private String getFileExtension(String fileName) {
-    List<String> possibleExtensions = Arrays.asList(".jpg",".png",".jpeg");
+    List<String> possibleExtensions = Arrays.asList(".jpg", ".png", ".jpeg");
     String extension = fileName.substring(fileName.lastIndexOf("."));
     if (!possibleExtensions.contains(extension)) {
       throw new ImageUploadException(IMAGE_WRONG_FILE_FORMAT);
@@ -73,8 +78,8 @@ public class S3Uploader {
 
 
   /**
-   * @param file MultipartFile
-   * @param fileName createFileName 메서드를 통해서 변경된 파일 이름
+   * @param file           MultipartFile
+   * @param fileName       createFileName 메서드를 통해서 변경된 파일 이름
    * @param objectMetadata MultipartFile의 length와 contentType을 가진 객체
    */
   private void uploadToS3(MultipartFile file, String fileName, ObjectMetadata objectMetadata) {
@@ -102,7 +107,7 @@ public class S3Uploader {
    * @param multipartFile 사용자가 촬영한 이미지 파일
    * @return 서버 전송 결과 메시지 + 분석 결과값 반환
    */
-  public UploadDto sendToAiServer(MultipartFile multipartFile) throws IOException{
+  public UploadDto sendToAiServer(MultipartFile multipartFile) throws IOException {
     final String endPoint = aiUrl;
 
     String fileUrl = uploadFile(multipartFile);
@@ -125,6 +130,8 @@ public class S3Uploader {
 
     // AI 서버로 요청 전송 및 응답 처리
     int responseCode = connection.getResponseCode();
+
+    Long trashId = -1L;
     if (responseCode == HttpURLConnection.HTTP_OK) {
       // 성공적으로 이미지 전달했을 경우
       BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
@@ -136,16 +143,37 @@ public class S3Uploader {
       }
       in.close();
 
-      return new UploadDto("AI 서버에 이미지 전송 성공", removeEscape(response.toString()));
+      String resultValue = removeEscape(response.toString());
+      //단일 품목이며, 조회가 가능한 품목인 경우 상세조회할 trash의 id를 반환함.
+      trashId = judgeItCanSeacrh(resultValue);
+      return new UploadDto("AI 서버에 이미지 전송 성공", resultValue, trashId);
     } else {
       // 전달 실패
-      return new UploadDto("AI 서버에 이미지 전송 실패", null);
+      return new UploadDto("AI 서버에 이미지 전송 실패", null, trashId);
+    }
+  }
+
+  private Long judgeItCanSeacrh(String resultValue) {
+    //단일 재질인지 판단
+    if (resultValue.contains("],[")) {
+      return -1L;
+    }
+
+    //단일 재질인 경우에도, 조회가 가능한 데이터인지 판단
+    int endIndex = resultValue.indexOf(",");
+    String keyword = resultValue.substring(2, endIndex);
+    Optional<Trash> trash = trashRepository.findByNameAndParentTrashIsNotNull(
+        keyword);   //keyword와 동일한 name을 가지고 있으며, parentTrash가  null이 아닌 경우를 찾음.
+    if (trash.isPresent()) {
+      return trash.get().getId();
+    } else {
+      return -1L;
     }
   }
 
   private String removeEscape(String response) {
     return response.replace("\"", "")
-                   .replace("bboxes:", "")
+        .replace("bboxes:", "")
         .replace("{", "")
         .replace("}", "");
   }

--- a/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
+++ b/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
@@ -145,7 +145,7 @@ public class S3Uploader {
 
       String resultValue = removeEscape(response.toString());
       //단일 품목이며, 조회가 가능한 품목인 경우 상세조회할 trash의 id를 반환함.
-      trashId = judgeItCanSeacrh(resultValue);
+      trashId = judgeItCanBeSearched(resultValue);
       return new UploadDto("AI 서버에 이미지 전송 성공", resultValue, trashId);
     } else {
       // 전달 실패
@@ -153,7 +153,7 @@ public class S3Uploader {
     }
   }
 
-  private Long judgeItCanSeacrh(String resultValue) {
+  private Long judgeItCanBeSearched(String resultValue) {
     //단일 재질인지 판단
     if (resultValue.contains("],[")) {
       return -1L;

--- a/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
+++ b/src/main/java/com/sesacthon/infra/s3/service/S3Uploader.java
@@ -162,8 +162,7 @@ public class S3Uploader {
     //단일 재질인 경우에도, 조회가 가능한 데이터인지 판단
     int endIndex = resultValue.indexOf(",");
     String keyword = resultValue.substring(2, endIndex);
-    Optional<Trash> trash = trashRepository.findByNameAndParentTrashIsNotNull(
-        keyword);   //keyword와 동일한 name을 가지고 있으며, parentTrash가  null이 아닌 경우를 찾음.
+    Optional<Trash> trash = trashRepository.findByNameContainingAndParentTrashIsNotNull(keyword);   //keyword를 포함한 name이며, parentTrash가  null이 아닌 경우를 찾음.
     if (trash.isPresent()) {
       return trash.get().getId();
     } else {


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- #101 

## 🔑 Key Changes

1. /api/v1/image api의 응답 데이터에  id필드를 추가하였습니다.

## 📢 To Reviewers

이미지를 ai모델에 전달하여 응답된 값이 조회가능한 쓰레기인경우 해당쓰레기의 id필드에 고유id를 반환하며, 복합재질이나 조회할 수없는 품목인 경우 id필드에 -1를 반환합니다.  제 주관적인 생각으로 클라이언트 개발자의 로직처리를 최소화 하려고 이런 방식을 적용했습니다. 이후에 app개발자분과 이야기해서 최적의 방법을 반영하겠습니다!