### PR TITLE
feat: S3 아이콘 이미지 불러오는 기능 추가 구현

### DIFF
--- a/src/main/java/com/sesacthon/foreco/category/entity/Icon.java
+++ b/src/main/java/com/sesacthon/foreco/category/entity/Icon.java
@@ -2,5 +2,60 @@ package com.sesacthon.foreco.category.entity;
 
 public enum Icon {
 
+  //재활용 가능 종이
+  BOX("box.png"),
+  NEWSPAPER("newspaper.png"),
+  BOOK("book.png"),
+  PAPER_BAG("paperBag.png"),
+  AD_PAPER("adPaper.png"),
+  WORK_PAPER("workPaper.png"),
+  WALL_PAPER("wallPaper.png"),
+  BUJIGPO("bujigpo.png"),
+  RECEIPT("receipt.png"),
+
+  //플라스틱
+  PLASTIC("plastic.png"),
+  SPICE_JAR("spiceJar.png"),
+  STYROFOAM("styrofoam.png"),
+  AIRCAP("airCap.png"),
+  PLASTIC_WRAP("plasticWrap.png"),
+  RAINCOAT("raincoat.png"),
+  PAPER_PACK("paperPack.png"),
+  MOP("mop.png"),
+
+  //비닐
+  VINYL("vinyl.png"),
+  VINYL_BAG("vinylBag.png"),
+  VINYL_AD_PAPER("adPaper.png"),
+  VINYL_WORK_PAPER("workPaper.png"),
+
+  //대형폐기물
+  SOFA("sofa.png"),
+  BICYCLE("bicycle.png"),
+  BED("bed.png"),
+
+  //폐건전지, 폐형광등, 헌옷 - (특수)
+  BATTERY("battery.png"),
+  LAMP("lamp.png"),
+  OLD_CLOTHES("oldClothes.png"),
+
+  //일반쓰레기
+  UMBRELLA("umbrella.png"),
+  TOOTH_BRUSH("toothBrush.png"),
+  WASTE_TISSUE("wasteTissue.png"),
+  BANNER("banner.png"),
+  DELIVERY_DISH("deliveryDish.png"),
+  TENT("tent.png"),
+  EGG("egg.png");
+
+  private final String iconFile;
+
+  Icon(String iconFile) {
+    this.iconFile = iconFile;
+  }
+
+  public String getIconFile() {
+    return this.iconFile;
+  }
 
 }

--- a/src/main/java/com/sesacthon/foreco/category/entity/Trash.java
+++ b/src/main/java/com/sesacthon/foreco/category/entity/Trash.java
@@ -42,7 +42,8 @@ public class Trash {
   /**
    * 쓰레기 아이콘 이름
    */
-  private String trashIcon;
+  @Enumerated(STRING)
+  private Icon trashIcon;
 
   /**
    * 상위 카테고리 Id.

--- a/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashesDto.java
+++ b/src/main/java/com/sesacthon/foreco/trash/dto/RelevantTrashesDto.java
@@ -1,9 +1,6 @@
 package com.sesacthon.foreco.trash.dto;
 
-import com.sesacthon.foreco.category.entity.Trash;
-import com.sesacthon.foreco.trash.entity.TrashInfo;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -11,11 +8,15 @@ public class RelevantTrashesDto {
 
   private final List<RelevantTrashDto> recommendTrashes;
 
+//  public RelevantTrashesDto(List<TrashInfo> trashInfos){
+//    this.recommendTrashes = trashInfos.stream().map((trashInfo)->{
+//      Trash trash = trashInfo.getTrash();
+//
+//     return new RelevantTrashDto(trash.getId(), trash.getName(), trash.getTrashIcon());
+//    }).collect(Collectors.toList());
+//  }
 
-  public RelevantTrashesDto(List<TrashInfo> trashInfos){
-    this.recommendTrashes = trashInfos.stream().map((trashInfo)->{
-      Trash trash = trashInfo.getTrash();
-     return new RelevantTrashDto(trash.getId(), trash.getName(), trash.getTrashIcon());
-    }).collect(Collectors.toList());
+  public RelevantTrashesDto(List<RelevantTrashDto> recommendTrashes) {
+    this.recommendTrashes = recommendTrashes;
   }
 }

--- a/src/main/java/com/sesacthon/global/exception/ErrorCode.java
+++ b/src/main/java/com/sesacthon/global/exception/ErrorCode.java
@@ -35,8 +35,10 @@ public enum ErrorCode {
   TRASH_NOT_FOUND(HttpStatus.BAD_REQUEST, "T002", "현재 지역의 해당 쓰레기 배출 정보가 없습니다."),
 
   //관련 쓰레기
-  RELATED_TRASH_NOT_FOUND(HttpStatus.BAD_REQUEST, "T003", "현재 지역의 관련 쓰레기 배출 정보가 없습니다."),
+  RELATED_TRASH_NOT_FOUND(HttpStatus.BAD_REQUEST, "T003", "해당 쓰레기의 관련 쓰레기 정보가 없습니다."),
 
+  //AI
+  AI_SERVER_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "A001", "Ai 서버에 연결할 수 없습니다."),
 
   //이미지 저장
   IMAGE_WRONG_FILE_FORMAT(HttpStatus.BAD_REQUEST, "I001", "지원하지 않는 파일 확장자입니다."),
@@ -49,7 +51,6 @@ public enum ErrorCode {
   MOTIVATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "M001", "현재 쓰레기 관련 동기부여 정보가 없습니다."),
 
   //배출정보(Disposal)
-
   DISPOSAL_NOT_FOUND(HttpStatus.BAD_REQUEST,"D001", "현재 조회 가능한 배출 정보가 없습니다.");
 
 

--- a/src/main/java/com/sesacthon/infra/s3/exception/AiServerConnectionException.java
+++ b/src/main/java/com/sesacthon/infra/s3/exception/AiServerConnectionException.java
@@ -1,0 +1,12 @@
+package com.sesacthon.infra.s3.exception;
+
+import com.sesacthon.global.exception.BusinessException;
+import com.sesacthon.global.exception.ErrorCode;
+
+public class AiServerConnectionException extends BusinessException {
+
+  public AiServerConnectionException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+}


### PR DESCRIPTION
### ✒️ 관련 이슈번호
- Close #102 

## 🔑 Key Changes
1. Trash 엔티티에서 `String 타입의 iconUrl 필드`를 `Enum타입의 trashIcon필드`로 변경
2. Enum Icon 정의 

## 📢 To Reviewers
- 아이콘 이미지 url을 S3 downloader 서비스를 이용해서 가져오는 로직을 추가적으로 기존 로직에 넣는 도중에, 비효율적이지 않나하는 부분이 있어 재혁님과 논의해보고 싶습니다.
저는 연관있는 쓰레기를 구하는 로직에서는 관련 Trash만 가져오면 된다고 생각합니다!
현재 로직에서는 해당 쓰레기의 childTrashes를 가져오고 거기서 TrashInfo를 호출하고, 또 TrashInfo가 외래키로 가지고 있는 Trash를 가져오는 과정이 비효율적이라고 생각했습니다. 혹시 이렇게 하신 이유가 있나요??
일단 제가 생각한 로직대로 구현해서 넣었을 때 정상작동하는 걸 확인했고, 재혁님이 해주신 코드는 잠시 주석처리해놨는데요..!
```
List<TrashInfo> trashInfos = new ArrayList<>();
for (Trash childTrash : childTrashes) {
   Optional<TrashInfo> trashInfo = trashInfoRepository.findByTrashIdAndRegionId(childTrash.getId(), regionId);
   trashInfo.ifPresent(trashInfos::add);
}
```
말이 좀 길었네요 ㅎㅎ 결론은 관련쓰레기에서 TrashInfo를 가져오는 이유가 궁금합니다!