### PR TITLE
feat: 카카오 로그인 요청 방식 수정

### DIFF
--- a/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenReissueService.java
+++ b/src/main/java/com/sesacthon/foreco/jwt/service/JwtTokenReissueService.java
@@ -25,13 +25,12 @@ public class JwtTokenReissueService {
   public ReIssueTokenDto reIssueToken(String refreshToken) {
     UUID memberId = redisService.findMemberByToken(refreshToken);
     Member member = memberService.getMemberById(memberId);
-    String newAccessToken = jwtTokenProvider.createAccessToken(memberId, member.getRole());
 
-    if(jwtTokenProvider.isTokenExpirationSafe(refreshToken)) {
-      return new ReIssueTokenDto(newAccessToken, refreshToken);
-    }
+    String newAccessToken = jwtTokenProvider.createAccessToken(memberId, member.getRole());
     String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
     redisService.saveRefreshToken(memberId, newRefreshToken);
+
     return new ReIssueTokenDto(newAccessToken, newRefreshToken);
   }
 

--- a/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
+++ b/src/main/java/com/sesacthon/foreco/member/controller/MemberController.java
@@ -47,24 +47,43 @@ public class MemberController {
   /**
    * 인가코드를 통해 accessToken 과 유저 정보를 가져온다.
    */
+//  @Operation(
+//      summary = "카카오 계정 회원가입",
+//      description = "인가 코드를 입력하고 요청보내면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
+//  @GetMapping("/api/v1/account/kakao/result")
+//  public ResponseEntity<DataResponse<LoginResponseDto>> kakaoLogin(
+//      @RequestParam("code") String code,
+//      @RequestParam("redirectUri") String redirectUri,
+//      @RequestParam("region") String region ) {
+//
+//    //TODO: 쿠키, 헤더 사용하지 않고 바로 accessToken과 refreshToken을 발급해주는 방식으로 바꿀 예정
+//    //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
+//    KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code, redirectUri);
+//    //loginKakaoMember를 하면서 region도 함께 넘겨준다.
+//    LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo, region);
+//    return new ResponseEntity<>(
+//        DataResponse.of(
+//            HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse), HttpStatus.CREATED);
+//  }
+
   @Operation(
       summary = "카카오 계정 회원가입",
-      description = "인가 코드를 입력하고 요청보내면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
+      description = "토큰과 사용자의 지역정보로 요청하면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
   @GetMapping("/api/v1/account/kakao/result")
   public ResponseEntity<DataResponse<LoginResponseDto>> kakaoLogin(
-      @RequestParam("code") String code,
-      @RequestParam("redirectUri") String redirectUri,
+      @RequestParam("token") String token,
       @RequestParam("region") String region ) {
-
-    //TODO: 쿠키, 헤더 사용하지 않고 바로 accessToken과 refreshToken을 발급해주는 방식으로 바꿀 예정
     //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
-    KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code, redirectUri);
+    KakaoUserInfoResponseDto kakaoUser = kakaoFeignService.getKakaoInfo(token);
     //loginKakaoMember를 하면서 region도 함께 넘겨준다.
-    LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo, region);
+    LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUser, region);
     return new ResponseEntity<>(
         DataResponse.of(
             HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse), HttpStatus.CREATED);
   }
+
+
+
 
   /**
    * 유저가 자기 자신의 정보에 대해 알 수 있다.

--- a/src/main/java/com/sesacthon/infra/feign/service/KakaoFeignService.java
+++ b/src/main/java/com/sesacthon/infra/feign/service/KakaoFeignService.java
@@ -43,17 +43,17 @@ public class KakaoFeignService {
    * @param code 카카오 서버에서 내려준 인가 코드
    * @return 해당 사용자 정보 response dto
    */
-  public KakaoUserInfoResponseDto getKakaoInfoWithToken(String code, String redirectUri) {
-    //1. 인가 코드를 가지고 토큰을 가져온다.
-    String kakaoToken = getKakaoToken(code, redirectUri);
-    //2. 해당 토큰으로 user 정보를 들고온다.
-    return getKakaoInfo(kakaoToken);
-  }
+//  public KakaoUserInfoResponseDto getKakaoInfoWithToken(String code, String redirectUri) {
+//    //1. 인가 코드를 가지고 토큰을 가져온다.
+//    String kakaoToken = getKakaoToken(code, redirectUri);
+//    //2. 해당 토큰으로 user 정보를 들고온다.
+//    return getKakaoInfo(kakaoToken);
+//  }
 
   /**
    * 카카오 액세스 토큰으로 유저 정보를 요청합니다.
    */
-  private KakaoUserInfoResponseDto getKakaoInfo(String kakaoToken) {
+  public KakaoUserInfoResponseDto getKakaoInfo(String kakaoToken) {
     return kakaoInfoClient.getUserInfo(kakaoToken);
   }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,5 +1,3 @@
-#application-prod.yml
-
 awsParameterStorePropertySource:
   enabled: true
 
@@ -24,7 +22,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true
@@ -62,7 +60,6 @@ oauth2:
     infoUrl: https://kapi.kakao.com
     baseUrl: https://kauth.kakao.com
     clientId: dd6c51dc02204dacd84d70e52a877d8f
-    #TODO: 실제 배포 도메인 주소로 바꿔야 함
     secretKey: ${SECRET_KEY}
 
 ai:


### PR DESCRIPTION
### ✒️ 관련 이슈번호
- Close #114 

## 🔑 Key Changes
1. token으로 로그인 요청을 가져올 수 있는 API로 변경
2. refreshToken을 발급할 때, accessToken도 함께 항상 새로 발급할 수 있도록 변경
3. ddl-auto를 none으로 변경

## 📢 To Reviewers
- 클라이언트와 기능 동작 확인 후, 주석처리된 것은 지우도록 하겠습니다.