### PR TITLE
refactor: 쓰레기 퍼즐맞추기 미션 Mock api 수정

### DIFF
--- a/src/main/java/com/sesacthon/foreco/mock/mission/MissionMockController.java
+++ b/src/main/java/com/sesacthon/foreco/mock/mission/MissionMockController.java
@@ -5,8 +5,10 @@ import com.sesacthon.foreco.mission.entity.Kind;
 import com.sesacthon.foreco.mock.mission.dto.DashboardDto;
 import com.sesacthon.foreco.mock.mission.dto.MissionDetailDto;
 import com.sesacthon.foreco.mock.mission.dto.MissionDto;
+import com.sesacthon.foreco.mock.mission.dto.MissionInfo;
 import com.sesacthon.foreco.mock.mission.dto.MissionResultDto;
 import com.sesacthon.foreco.mock.mission.dto.MissionResultInfoDto;
+import com.sesacthon.foreco.mock.mission.dto.QuizMissionAnswer;
 import com.sesacthon.foreco.mock.mission.dto.QuizMissionChoice;
 import com.sesacthon.foreco.mock.mission.dto.QuizMissionDto;
 import com.sesacthon.global.response.DataResponse;
@@ -66,33 +68,39 @@ public class MissionMockController {
         HttpStatus.OK);
   }
 
-  @Operation(summary = "쓰레기 맞추기 미션 요청 api" , description = "조각난 쓰레기 사진을 보고 어떤 쓰레기인지 맞추는 미션 api")
+  @Operation(summary = "쓰레기 맞추기 미션 요청 api", description = "조각난 쓰레기 사진을 보고 어떤 쓰레기인지 맞추는 미션 api")
   @GetMapping("mock/api/v1/mission/{id}")
-  public ResponseEntity<DataResponse<QuizMissionDto>> getMission1(@PathVariable(name = "id") Long id){
+  public ResponseEntity<DataResponse<QuizMissionDto>> getMission1(
+      @PathVariable(name = "id") Long id) {
 
     //실제 구현시, s3에 업로드하여 url로 반환해야함. -> 요청마다 url생성을 위해서 일회성 이미지를 업로드 하는 것이 맞는 건가...?
     List<String> images = Arrays.asList("url1", "url2", "url3", "url4");
     List<QuizMissionChoice> choices = new ArrayList<>();
-    for (int i = 1; i <= 4; i++) {
-      String name = String.valueOf(i)+"번 선택지";
-      choices.add(new QuizMissionChoice(i, name));
-    }
-    QuizMissionChoice answer = new QuizMissionChoice(2, "2번 선택지");
-    QuizMissionDto response = new QuizMissionDto(images, choices, answer);
+    choices.add(new QuizMissionChoice(1L, "소파"));
+    choices.add(new QuizMissionChoice(2L, "의류"));
+    choices.add(new QuizMissionChoice(3L, "형광등"));
+    choices.add(new QuizMissionChoice(4L, "소주병"));
+    QuizMissionAnswer answer = new QuizMissionAnswer(1L, "소파", "소파이미지url", "지자체에 신고 후 버려주세요.");
+    MissionInfo missionInfo = new MissionInfo(2000L, "쓰레기 퍼즐 맞추기", "아래에 조각난 쓰레기는 무엇일까요?", 1L, 5L);
 
-    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK,"퀴즈 미션 요청 성공", response), HttpStatus.OK);
+    QuizMissionDto response = new QuizMissionDto(missionInfo, images, choices, answer);
+
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "퀴즈 미션 요청 성공", response),
+        HttpStatus.OK);
   }
 
-  @Operation(summary = "요청 결과 반영 api" , description = "미션 수행이후 결과를 반영하고, 변경된 포인트 이력을 보여줍니다.")
+  @Operation(summary = "요청 결과 반영 api", description = "미션 수행이후 결과를 반영하고, 변경된 포인트 이력을 보여줍니다.")
   @PostMapping("mock/api/v1/mission/result")
-  public ResponseEntity<DataResponse<MissionResultInfoDto>> updateMissionResult(@RequestBody  MissionResultDto missionResultDto){
+  public ResponseEntity<DataResponse<MissionResultInfoDto>> updateMissionResult(
+      @RequestBody MissionResultDto missionResultDto) {
     //TODO 실제 api 구현시 contextHolder에서 값을 가져온 후  user의 id를 활용해야함
-      //유저아이디를 조회후, rewardPoint반영
+    //유저아이디를 조회후, rewardPoint반영
     //성공했으면, 성공을 반영
     //실패했으면, 실패를 반영.
     //사용자
     MissionResultInfoDto response = new MissionResultInfoDto(5L, 10L);
-    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "결과 반영 성공", response), HttpStatus.OK);
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "결과 반영 성공", response),
+        HttpStatus.OK);
 
   }
 }

--- a/src/main/java/com/sesacthon/foreco/mock/mission/dto/MissionInfo.java
+++ b/src/main/java/com/sesacthon/foreco/mock/mission/dto/MissionInfo.java
@@ -1,0 +1,23 @@
+package com.sesacthon.foreco.mock.mission.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MissionInfo {
+
+  Long rewardPoint;
+  String title;
+  String description;
+  Long personalParticipatingCount;
+  Long personalCount;
+
+  public MissionInfo(Long rewardPoint, String title, String description,
+      Long personalParticipatingCount, Long personalCount) {
+    this.rewardPoint = rewardPoint;
+    this.title = title;
+    this.description = description;
+    this.personalParticipatingCount = personalParticipatingCount;
+    this.personalCount = personalCount;
+  }
+}
+

--- a/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionAnswer.java
+++ b/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionAnswer.java
@@ -1,0 +1,19 @@
+package com.sesacthon.foreco.mock.mission.dto;
+
+import lombok.Getter;
+
+@Getter
+public class QuizMissionAnswer {
+
+  Long id;
+  String name;
+  String imageUrl;
+  String disposalMethod;
+
+  public QuizMissionAnswer(Long id, String name, String imageUrl, String disposalMethod) {
+    this.id = id;
+    this.name = name;
+    this.imageUrl = imageUrl;
+    this.disposalMethod = disposalMethod;
+  }
+}

--- a/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionChoice.java
+++ b/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionChoice.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 @Getter
 public class QuizMissionChoice {
 
-  Integer id;
+  Long id;
   String name;
 
-  public QuizMissionChoice(Integer id, String name) {
+  public QuizMissionChoice(Long id, String name) {
     this.id = id;
     this.name = name;
   }

--- a/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionDto.java
+++ b/src/main/java/com/sesacthon/foreco/mock/mission/dto/QuizMissionDto.java
@@ -6,12 +6,15 @@ import lombok.Getter;
 @Getter
 public class QuizMissionDto {
 
+  MissionInfo missionInfo;
   List<String> images;
   List<QuizMissionChoice> choices;
-  QuizMissionChoice answer;
+  QuizMissionAnswer answer;
 
-  public QuizMissionDto(List<String> images, List<QuizMissionChoice> choices,
-      QuizMissionChoice answer) {
+  public QuizMissionDto(MissionInfo missionInfo, List<String> images,
+      List<QuizMissionChoice> choices,
+      QuizMissionAnswer answer) {
+    this.missionInfo = missionInfo;
     this.images = images;
     this.choices = choices;
     this.answer = answer;


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Close #118 

## 🔑 Key Changes
- 쓰레기 맞추기 미션 mock api수정
 - 미션에 대한 정보를 나타내는 missionInfo필드를 추가했습니다.(리워드, 제목, 소개, 참여한 횟수, 해당 미션에 참여가능한 횟수)
 - answer필드에 정답이미지와 배출방법을 나타내는 필드를 추가했습니다. 

## 📢 To Reviewers

