### PR TITLE
fix: ai모델을 사용한 이미지 검색 로직 및 응답 형태 수정

### DIFF
--- a/src/main/java/com/sesacthon/foreco/mission/service/MissionService.java
+++ b/src/main/java/com/sesacthon/foreco/mission/service/MissionService.java
@@ -101,7 +101,8 @@ public class MissionService {
       choices.add(new QuizMissionChoice(++index, mixUpChoice));
       if (mixUpChoice.equals(answerInfo.getTrash())) {
         String disposalMethod = getDisposalMethod(answerInfo.getTrash());//배출방법 조회
-        answer = new QuizMissionAnswer(index, answerInfo.getTrash(), "https://" + bucket+answerInfo.getUrl(),
+        answer = new QuizMissionAnswer(index, answerInfo.getTrash(),
+            "https://" + bucket + answerInfo.getUrl(),
             disposalMethod);
       }
     }
@@ -173,20 +174,25 @@ public class MissionService {
   }
 
 
-  public List<MissionDetailDto> findMissionsWithKindAndDifficulty(String kind, String difficulty, UUID memberId) {
+  public List<MissionDetailDto> findMissionsWithKindAndDifficulty(String kind, String difficulty,
+      UUID memberId) {
     List<Mission> missions =
-        missionRepository.findByKindAndDifficulth(Kind.valueOf(kind), Difficulty.valueOf(difficulty));
+        missionRepository.findByKindAndDifficulth(Kind.valueOf(kind),
+            Difficulty.valueOf(difficulty));
     return createEntityToDto(missions, memberId);
   }
 
   private List<MissionDetailDto> createEntityToDto(List<Mission> missions, UUID memberId) {
     return missions.stream()
         .map(mission -> {
-          List<Participation> totalParticipation = participationRepository.findByMissionId(mission.getId());
+          List<Participation> totalParticipation = participationRepository.findByMissionId(
+              mission.getId());
           long totalParticipationSize = totalParticipation.size();
-          long personalParticipationSize = getPersonalParticipationSize(memberId, totalParticipation);
+          long personalParticipationSize = getPersonalParticipationSize(memberId,
+              totalParticipation);
           String iconUrl = s3Downloader.getIconUrl(mission.getIcon().getIconFile());
-          return new MissionDetailDto(mission, personalParticipationSize, totalParticipationSize, iconUrl);
+          return new MissionDetailDto(mission, personalParticipationSize, totalParticipationSize,
+              iconUrl);
         })
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/sesacthon/foreco/trash/service/TrashService.java
+++ b/src/main/java/com/sesacthon/foreco/trash/service/TrashService.java
@@ -66,13 +66,15 @@ public class TrashService {
     //id로 trash 객체를 가져옴
     Trash trash = trashRepository.findById(id)
         .orElseThrow(() -> new TrashNotFoundException(ErrorCode.TRASH_NOT_FOUND));
-
+    log.info("trash{}:", trash);
     //trashInfo가져옴
     TrashInfo trashInfo = trashInfoRepository.findByTrashIdAndRegionId(trash.getId(), regionId)
         .orElseThrow(() -> new TrashNotFoundException(ErrorCode.TRASH_NOT_FOUND));
+    log.info("trashInfo{}:", trashInfo);
 
     //배출 정보를 가져옴
     List<Disposal> disposals = getDisposals(regionId, trash);
+    log.info("disposal{}:", disposals);
 
     TrashDetailDto trashDetailDto = TrashDetailDto.builder()
         .id(trash.getId())

--- a/src/main/java/com/sesacthon/infra/feign/client/mission/QuizMissionClient.java
+++ b/src/main/java/com/sesacthon/infra/feign/client/mission/QuizMissionClient.java
@@ -1,10 +1,13 @@
 package com.sesacthon.infra.feign.client.mission;
 
+import com.sesacthon.infra.feign.dto.request.ImageAnalyzeRequestDto;
 import com.sesacthon.infra.feign.dto.request.ImageDivisionRequestDto;
+import com.sesacthon.infra.feign.dto.response.ImageAnalyzeResponseDto;
 import com.sesacthon.infra.feign.dto.response.ImageDivisionResponseDto;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.multipart.MultipartFile;
 
 @FeignClient(name = "QuizMissionAiServerApi", url ="${AI_MISSION_URL}")
 public interface QuizMissionClient {
@@ -12,4 +15,6 @@ public interface QuizMissionClient {
   @PostMapping(value ="/Wiz-mission-randomCrop")
   public ImageDivisionResponseDto divideImage(ImageDivisionRequestDto imageDivisionDto);
 
+  @PostMapping(value ="/Wiz-upload")
+  public ImageAnalyzeResponseDto analyzeImage(ImageAnalyzeRequestDto imageAnalyzeRequestDto);
 }

--- a/src/main/java/com/sesacthon/infra/feign/dto/request/ImageAnalyzeRequestDto.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/request/ImageAnalyzeRequestDto.java
@@ -1,0 +1,12 @@
+package com.sesacthon.infra.feign.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ImageAnalyzeRequestDto {
+  @Schema(description = "분석할 이미지 url")
+  private final String image_url;
+}

--- a/src/main/java/com/sesacthon/infra/feign/dto/response/ImageAnalyzeResponseDto.java
+++ b/src/main/java/com/sesacthon/infra/feign/dto/response/ImageAnalyzeResponseDto.java
@@ -1,0 +1,12 @@
+package com.sesacthon.infra.feign.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+
+
+@Getter
+public class ImageAnalyzeResponseDto {
+
+  private List<List<String>> bboxes;
+
+}

--- a/src/main/java/com/sesacthon/infra/s3/controller/S3Controller.java
+++ b/src/main/java/com/sesacthon/infra/s3/controller/S3Controller.java
@@ -1,29 +1,23 @@
 package com.sesacthon.infra.s3.controller;
 
 import com.sesacthon.infra.s3.dto.UploadDto;
+import com.sesacthon.infra.s3.dto.AiImageAnalyzeDto;
 import com.sesacthon.infra.s3.service.S3Uploader;
 import com.sesacthon.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cglib.core.Local;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -38,7 +32,7 @@ public class S3Controller {
 
   @Operation(summary = "카메라로 쓰레기 분석", description = "촬영 사진을 요청하면 AI 모델의 분석 결과값을 확인할 수 있습니다.")
   @PostMapping(value = "/api/v1/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<DataResponse<UploadDto>> uploadEventImg(
+  public ResponseEntity<DataResponse<AiImageAnalyzeDto>> uploadEventImg(
       HttpServletRequest request,
       HttpMethod httpMethod,
       Locale locale /*언어 정보로, 가장 우선순위가 높은 것을 받는다.*/,
@@ -51,20 +45,9 @@ public class S3Controller {
     log.info("locale={}", locale);
     log.info("headerMap={}", headerMap);
 
-    UploadDto uploadDto = s3Uploader.sendToAiServer(multipartFile);
+    AiImageAnalyzeDto aiImageAnalyzeDto = s3Uploader.sendToAiServer(multipartFile);
     return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.CREATED, "촬영 이미지 업로드 성공", uploadDto), HttpStatus.CREATED);
-  }
-
-  @Operation(summary = "카메라로 쓰레기 분석test", description = "촬영 사진을 요청하면 AI 모델의 분석 결과값을 확인할 수 있습니다.")
-  @PostMapping(value = "/api/v1/image/test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<DataResponse<UploadDto>> uploadEventImgtest(
-      @RequestPart("img") MultipartFile multipartFile
-  ) throws IOException {
-
-    UploadDto uploadDto = s3Uploader.sendToAiServer(multipartFile);
-    return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.CREATED, "촬영 이미지 업로드 성공", uploadDto), HttpStatus.CREATED);
+        DataResponse.of(HttpStatus.CREATED, "촬영 이미지 업로드 성공", aiImageAnalyzeDto), HttpStatus.CREATED);
   }
 
   @PostMapping(value = "/api/v1/image/prefix", consumes = {MediaType.ALL_VALUE,MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/sesacthon/infra/s3/dto/AiImageAnalyzeDto.java
+++ b/src/main/java/com/sesacthon/infra/s3/dto/AiImageAnalyzeDto.java
@@ -1,0 +1,18 @@
+package com.sesacthon.infra.s3.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AiImageAnalyzeDto {
+  private final String message;
+  private final List<AnalyzedImageDetailDto> result;
+  private final Long id;
+
+
+  public AiImageAnalyzeDto(String message, List<AnalyzedImageDetailDto> result, Long id) {
+    this.message = message;
+    this.result = result;
+    this.id = id;
+  }
+}

--- a/src/main/java/com/sesacthon/infra/s3/dto/AnalyzedImageDetailDto.java
+++ b/src/main/java/com/sesacthon/infra/s3/dto/AnalyzedImageDetailDto.java
@@ -1,0 +1,15 @@
+package com.sesacthon.infra.s3.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AnalyzedImageDetailDto {
+  private final String name;
+  private final List<Integer> coordinate;
+
+  public AnalyzedImageDetailDto(String name, List<Integer> coordinate) {
+    this.name = name;
+    this.coordinate = coordinate;
+  }
+}

--- a/src/main/java/com/sesacthon/infra/s3/dto/AnalyzedImageDto.java
+++ b/src/main/java/com/sesacthon/infra/s3/dto/AnalyzedImageDto.java
@@ -1,0 +1,10 @@
+package com.sesacthon.infra.s3.dto;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AnalyzedImageDto {
+  private final String trashName;
+  private final List<Integer> coordinate;
+}


### PR DESCRIPTION
기존에 ai서버에 요청하던 방식을 openfeign을 사용하는 방식으로 변경하였습니다. 또한 응답 형태 역시 바꿨습니다.

### ✒️ 관련 이슈번호

- Close #132 

## 🔑 Key Changes

1. 기존에 ai서버에 요청하는 방식을 openfeign을 사용하는 형태로 변경했습니다.
2. ai모델이 분석한 이미지의 이름과 좌표를 따로 분리하여 리스트 형태로 반환하도록 했습니다.

## 📢 To Reviewers

- 반환되는 id가 -1인 경우는
 - ai가 이미지를 인식하지 못한 경우 입니다. 
 - ai가 분석한 사물의 이름이, 저희 데이터베이스에 존재하지 않는 경우
 - 복합재질인 경우 입니다.